### PR TITLE
Event error because of the duplicated event identifier

### DIFF
--- a/PacklinkPro/etc/events.xml
+++ b/PacklinkPro/etc/events.xml
@@ -8,7 +8,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="sales_order_place_after">
+    <event name="sales_order_place_before">
         <observer name="packlink_sales_order_place_before"
                   instance="Packlink\PacklinkPro\Observer\SalesOrderPlaceBefore"/>
     </event>


### PR DESCRIPTION
This solution is for the event error of the issue #9 

The error is the following: 
````
Magento\Framework\Exception\LocalizedException: The XML in file "/var/www/html/test-magento2/vendor/packlink/magento2/etc/events.xml" is invalid:
Element 'event': Duplicate key-sequence ['sales_order_place_after'] in unique identity-constraint 'uniqueEventName'.
Line: 15
````