### PR TITLE
include external css using src attribute

### DIFF
--- a/PacklinkPro/view/adminhtml/layout/packlink_content_dashboard.xml
+++ b/PacklinkPro/view/adminhtml/layout/packlink_content_dashboard.xml
@@ -15,8 +15,7 @@
         <css src="Packlink_PacklinkPro::css/packlink.css"/>
         <css src="Packlink_PacklinkPro::css/packlink-checkout.css"/>
         <css src="Packlink_PacklinkPro::css/packlink-order-details.css"/>
-        <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"
-              rel="stylesheet"/>
+        <css src="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"  src_type="url" rel="stylesheet" type="text/css"/>
         <link src="Packlink_PacklinkPro::packlink/js/TemplateService.js"/>
         <link src="Packlink_PacklinkPro::packlink/js/AjaxService.js"/>
         <link src="Packlink_PacklinkPro::packlink/js/AutoTestController.js"/>


### PR DESCRIPTION
When we click on the Sales > Packlink Pro in Magento 2.4.2-p1, an error appears.

Error Element 'link': The attribute 'src' is required but missing

This pull request resolves the issue #19